### PR TITLE
Add style context to configure where style is injected

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,3 @@
 {
-  "workbench.colorCustomizations": {
-    "activityBar.background": "#5672a0",
-    "titleBar.activeBackground": "#476ba5",
-    "titleBar.activeForeground": "#FBFAF9"
-  }
+
 }

--- a/src/hooks/use-multi-select.tsx
+++ b/src/hooks/use-multi-select.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useContext, useEffect, useMemo, useState } from "react";
 
-import { injectStyles } from "../lib/inject-style";
+import { injectStyles, MultiSelectStyleContext } from "../lib/inject-style";
 import { ISelectProps, Option } from "../lib/interfaces";
 
 const defaultStrings = {
@@ -44,7 +44,8 @@ export const MultiSelectProvider = ({
   const [options, setOptions] = useState(props.options);
   const t = (key) => props.overrideStrings?.[key] || defaultStrings[key];
 
-  useMemo(() => injectStyles(), []);
+  const styleContext = useContext(MultiSelectStyleContext);
+  useMemo(() => injectStyles(styleContext), [styleContext]);
 
   useEffect(() => {
     setOptions(props.options);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,5 +2,12 @@ import MultiSelect from "./multi-select";
 import Dropdown from "./multi-select/dropdown";
 import SelectPanel from "./select-panel";
 import SelectItem from "./select-panel/select-item";
+import { MultiSelectStyleProvider } from "./lib/inject-style";
 
-export { Dropdown, MultiSelect, SelectItem, SelectPanel };
+export {
+  Dropdown,
+  MultiSelect,
+  SelectItem,
+  SelectPanel,
+  MultiSelectStyleProvider,
+};

--- a/src/lib/inject-style.tsx
+++ b/src/lib/inject-style.tsx
@@ -1,12 +1,32 @@
+import React from "react";
+import { createContext } from "react";
 import styles from "../style.css";
 
 let styleElement: HTMLStyleElement | undefined;
 
-export const injectStyles = () => {
+interface StyleContext {
+  container: HTMLElement;
+}
+const defaultStyleContext = { container: document.head };
+
+export const MultiSelectStyleContext =
+  createContext<StyleContext>(defaultStyleContext);
+
+export const MultiSelectStyleProvider: React.FC<StyleContext> = (props) => {
+  return (
+    <MultiSelectStyleContext.Provider value={props}>
+      {props.children}
+    </MultiSelectStyleContext.Provider>
+  );
+};
+
+export const injectStyles = (props: StyleContext) => {
+  const options = { ...defaultStyleContext, ...props };
+
   if (typeof document !== "undefined" && !styleElement) {
     styleElement = document.createElement("style");
     styleElement.innerHTML = styles;
 
-    document.head.appendChild(styleElement);
+    options.container.appendChild(styleElement);
   }
 };


### PR DESCRIPTION
If you want to mount the component in a shadow root, for example in the case that it's being used in a web-component, then you would add this to your react app:

```js
import { MultiSelectStyleProvider } from 'react-multi-select-component';

const TopLevelApp = () => {
  return <MultiSelectStyleProvider container={shadowRootElement}>
    <RestOfApp />
  </MultiSelectStyleProvider>;
};
```