### PR TITLE
feat(no-inject-style): added second build with no style injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ yarn add react-multi-select-component # yarn
 ```tsx
 import React, { useState } from "react";
 import { MultiSelect } from "react-multi-select-component";
+// or without style injection (in the presence of Content Security Policy issues)
+// import { MultiSelect } from "react-multi-select-component/no-inject-style";
+// import  "react-multi-select-component/no-inject-style/index.css";
 
 const options = [
   { label: "Grapes 🍇", value: "grapes" },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.tsx --inject-style --legacy-output --minify --format esm,cjs --dts --external react",
+    "build:no-inject-style": "tsup src/index.tsx --outDir dist/no-inject-style --legacy-output --minify --format esm,cjs --dts --external react",
+    "build:inject-style": "tsup src/index.tsx --inject-style --legacy-output --minify --format esm,cjs --dts --external react",
+    "build": "yarn run build:inject-style && yarn run build:no-inject-style",
     "dev": "tsup src/index.tsx --inject-style --legacy-output --format esm,cjs --watch --dts --external react",
     "lint": "eslint src --fix",
     "size": "size-limit",

--- a/stories.bak/basic.stories.tsx
+++ b/stories.bak/basic.stories.tsx
@@ -1,0 +1,39 @@
+import { boolean, text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import { MultiSelect } from "../dist/no-inject-style";
+import { options } from "./constants";
+
+export default {
+  title: "Basic",
+  decorators: [withKnobs],
+};
+
+export const ExampleDefault = () => {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+      <MultiSelect
+        options={options}
+        hasSelectAll={boolean("hasSelectAll", true)}
+        isLoading={boolean("isLoading", false)}
+        shouldToggleOnHover={boolean("shouldToggleOnHover", false)}
+        disableSearch={boolean("disableSearch", false)}
+        value={selected}
+        disabled={boolean("disabled", false)}
+        onChange={setSelected}
+        onMenuToggle={(s) => {
+          console.debug("Select Toggle: ", s);
+        }}
+        labelledBy={text("labelledBy", "Select Fruits")}
+        className={text("className", "multi-select")}
+      />
+    </div>
+  );
+};
+
+ExampleDefault.story = {
+  name: "Basic",
+};

--- a/stories.bak/constants.ts
+++ b/stories.bak/constants.ts
@@ -1,0 +1,11 @@
+export const options = [
+  { label: "Grapes 🍇", value: "grapes" },
+  { label: "Mango 🥭", value: "mango" },
+  { label: "Strawberry 🍓", value: "strawberry", disabled: true },
+  { label: "Watermelon 🍉", value: "watermelon" },
+  { label: "Pear 🍐", value: "pear" },
+  { label: "Apple 🍎", value: "apple" },
+  { label: "Tangerine 🍊", value: "tangerine" },
+  { label: "Pineapple 🍍", value: "pineapple" },
+  { label: "Peach 🍑", value: "peach" },
+];

--- a/stories.bak/creatable-custom.stories.tsx
+++ b/stories.bak/creatable-custom.stories.tsx
@@ -1,0 +1,46 @@
+import { text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import MultiSelect from "../src/multi-select";
+
+export default {
+  title: "Creatable",
+  decorators: [withKnobs],
+};
+
+const INITIAL_OPTIONS = [
+  { label: "Grapes 🍇", value: "grapes" },
+  { label: "Mango 🥭", value: "mango", disabled: true },
+  { label: "Strawberry 🍓", value: "strawberry" },
+];
+
+export const CreatableCustom = () => {
+  /**
+   * overrides default `onCreateOption` allows you to modify newly added option
+   */
+  const handleNewField = (value) => ({
+    label: value,
+    value: value.toUpperCase(),
+  });
+
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+
+      <MultiSelect
+        options={INITIAL_OPTIONS}
+        value={selected}
+        onChange={setSelected}
+        labelledBy={text("labelledBy", "Select Fruits")}
+        isCreatable={true}
+        onCreateOption={handleNewField} // <--
+      />
+    </div>
+  );
+};
+
+CreatableCustom.story = {
+  name: "Creatable Custom onCreateOption",
+};

--- a/stories.bak/creatable.stories.tsx
+++ b/stories.bak/creatable.stories.tsx
@@ -1,0 +1,37 @@
+import { text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import MultiSelect from "../src/multi-select";
+
+export default {
+  title: "Creatable",
+  decorators: [withKnobs],
+};
+
+const INITIAL_OPTIONS = [
+  { label: "Grapes 🍇", value: "grapes" },
+  { label: "Mango 🥭", value: "mango", disabled: true },
+  { label: "Strawberry 🍓", value: "strawberry" },
+];
+
+export const CreatableDefault = () => {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+
+      <MultiSelect
+        options={INITIAL_OPTIONS}
+        value={selected}
+        onChange={setSelected}
+        labelledBy={text("labelledBy", "Select Fruits")}
+        isCreatable={true}
+      />
+    </div>
+  );
+};
+
+CreatableDefault.story = {
+  name: "Creatable",
+};

--- a/stories.bak/custom-arrow.stories.tsx
+++ b/stories.bak/custom-arrow.stories.tsx
@@ -1,0 +1,38 @@
+import { text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import MultiSelect from "../src/multi-select";
+import { options } from "./constants";
+
+export default {
+  title: "Custom Arrow",
+  decorators: [withKnobs],
+};
+
+export const ExampleCustomArrow = () => {
+  const [selected, setSelected] = useState([]);
+
+  const ArrowRenderer = ({ expanded }) => <>{expanded ? "🦉" : "🦚"}</>;
+
+  const CustomClearIcon = () => <div>🤘</div>;
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+      <MultiSelect
+        options={options}
+        value={selected}
+        onChange={setSelected}
+        labelledBy={text("labelledBy", "Select Fruits")}
+        ArrowRenderer={ArrowRenderer}
+        onMenuToggle={(isOpen) => console.debug("onMenuToggle", isOpen)}
+        ClearIcon={<CustomClearIcon />}
+        ClearSelectedIcon={<CustomClearIcon />}
+      />
+    </div>
+  );
+};
+
+ExampleCustomArrow.story = {
+  name: "Arrow",
+};

--- a/stories.bak/custom-element-story.css
+++ b/stories.bak/custom-element-story.css
@@ -1,0 +1,19 @@
+.mso .dropdown-container {
+  border: 0;
+  display: inline-block;
+  width: 100%;
+}
+
+.mso .dropdown-container:focus-within {
+  box-shadow: none;
+  border-color: transparent;
+}
+
+.mso .dropdown-heading {
+  padding: 0;
+  height: auto;
+}
+
+.mso .dropdown-heading-dropdown-arrow {
+  display: none;
+}

--- a/stories.bak/custom-element.stories.tsx
+++ b/stories.bak/custom-element.stories.tsx
@@ -1,0 +1,88 @@
+import "./custom-element-story.css";
+
+import { boolean, text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import MultiSelect from "../src/multi-select";
+import { options } from "./constants";
+
+export default {
+  title: "Custom Element",
+  decorators: [withKnobs],
+};
+
+export const ExampleWithStrings = () => {
+  const [selected, setSelected] = useState<typeof options>([]);
+
+  const valueRenderer = (selected: typeof options) => {
+    if (!selected.length) {
+      return "No Item Selected";
+    }
+
+    return selected.length === 1
+      ? `${selected[0].label} 😶`
+      : selected.map(({ label }) => "✔️ " + label);
+  };
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+      <MultiSelect
+        options={options}
+        hasSelectAll={boolean("hasSelectAll", true)}
+        isLoading={boolean("isLoading", false)}
+        shouldToggleOnHover={boolean("shouldToggleOnHover", false)}
+        disableSearch={boolean("disableSearch", false)}
+        value={selected}
+        disabled={boolean("disabled", false)}
+        onChange={setSelected}
+        valueRenderer={valueRenderer}
+        labelledBy={text("labelledBy", "Select Fruits")}
+        className={text("className", "multi-select")}
+      />
+    </div>
+  );
+};
+
+ExampleWithStrings.story = {
+  name: "With Strings",
+};
+
+export const ExampleWithReactNode = () => {
+  const [selected, setSelected] = useState<typeof options>([]);
+
+  const valueRenderer = (selected: typeof options) => {
+    if (!selected.length) {
+      return <button>Toggle Dropdown!</button>;
+    }
+
+    return selected.length === 1 ? (
+      <button>{selected[0].label} 😶</button>
+    ) : (
+      selected.map(({ label }) => <button key={label}>✔️ {label}</button>)
+    );
+  };
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+      <MultiSelect
+        options={options}
+        hasSelectAll={boolean("hasSelectAll", true)}
+        isLoading={boolean("isLoading", false)}
+        shouldToggleOnHover={boolean("shouldToggleOnHover", false)}
+        disableSearch={boolean("disableSearch", false)}
+        value={selected}
+        disabled={boolean("disabled", false)}
+        onChange={setSelected}
+        valueRenderer={valueRenderer}
+        labelledBy={text("labelledBy", "Select Fruits")}
+        className={text("className", "multi-select mso")}
+      />
+    </div>
+  );
+};
+
+ExampleWithReactNode.story = {
+  name: "With Element",
+};

--- a/stories.bak/custom-filter.stories.tsx
+++ b/stories.bak/custom-filter.stories.tsx
@@ -1,0 +1,39 @@
+import { text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import MultiSelect from "../src/multi-select";
+
+export default {
+  title: "Custom Filter",
+  decorators: [withKnobs],
+};
+
+const customFilterOptions = async (_options, filter) => {
+  const opts = await fetch(`https://swapi.dev/api/people/?search=${filter}`)
+    .then((r) => r.json())
+    .then(({ results }) =>
+      results.map(({ name: label }) => ({ label, value: label }))
+    );
+  return opts;
+};
+
+export const ExampleCustomFilter = () => {
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+      <MultiSelect
+        options={[]}
+        value={selected}
+        onChange={setSelected}
+        filterOptions={customFilterOptions}
+        labelledBy={text("labelledBy", "Select Fruits")}
+      />
+    </div>
+  );
+};
+
+ExampleCustomFilter.story = {
+  name: "External Search Async",
+};

--- a/stories.bak/disabled.stories.tsx
+++ b/stories.bak/disabled.stories.tsx
@@ -1,0 +1,35 @@
+import { text, withKnobs } from "@storybook/addon-knobs";
+import React, { useState } from "react";
+
+import MultiSelect from "../src/multi-select";
+
+export default {
+  title: "Multiselect",
+  decorators: [withKnobs],
+};
+
+export const ExampleDisabled = () => {
+  const options = [
+    { label: "Grapes 🍇", value: "grapes" },
+    { label: "Mango 🥭", value: "mango", disabled: true },
+    { label: "Strawberry 🍓", value: "strawberry" },
+  ];
+
+  const [selected, setSelected] = useState([]);
+
+  return (
+    <div>
+      <pre>{JSON.stringify(selected)}</pre>
+      <MultiSelect
+        options={options}
+        value={selected}
+        onChange={setSelected}
+        labelledBy={text("labelledBy", "Select Fruits")}
+      />
+    </div>
+  );
+};
+
+ExampleDisabled.story = {
+  name: "Disabled",
+};

--- a/stories.bak/recipes/custom-filter.stories.mdx
+++ b/stories.bak/recipes/custom-filter.stories.mdx
@@ -1,0 +1,19 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="recipes/Custom Filter Logic" />
+
+# 🔍 Custom Filter Logic
+
+By default this component uses a fuzzy search algorithm to filter options but also allows you to opt-out and use your custom logic by specifying `filterOptions` prop to component
+
+example of case insensitive search
+
+```js
+const filterOptions = (options, filter) => {
+  if (!filter) {
+    return options;
+  }
+  const re = new RegExp(filter, "i");
+  return options.filter(({ value }) => value && value.match(re));
+};
+```

--- a/stories.bak/recipes/custom-item.stories.mdx
+++ b/stories.bak/recipes/custom-item.stories.mdx
@@ -1,0 +1,9 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="recipes/Custom Item Renderer" />
+
+# 🎛 Custom Item Renderer
+
+Optionally customise dropdown item by passing `ItemRenderer` prop
+
+[Default Item Renderer ↗](https://github.com/hc-oss/react-multi-select-component/blob/master/src/select-panel/default-item.tsx#L12-L28)

--- a/stories.bak/recipes/custom-value.stories.mdx
+++ b/stories.bak/recipes/custom-value.stories.mdx
@@ -1,0 +1,17 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="recipes/Custom Value Renderer" />
+
+# 🎛 Custom Value Renderer
+
+Optionally customise value renderer view by passing `valueRenderer` prop
+
+```js
+const customValueRenderer = (selected, _options) => {
+  return selected.length
+    ? selected.map(({ label }) => "✔️ " + label)
+    : "😶 No Items Selected";
+};
+```
+
+![Custom Value Renderer](https://user-images.githubusercontent.com/5774849/150685369-dd5426c5-1e91-441f-b461-9fd88844f8d0.gif)

--- a/stories.bak/recipes/localization.stories.mdx
+++ b/stories.bak/recipes/localization.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="recipes/Localization" />
+
+# 🌐 Localization
+
+You can easily Internationalize this component by passing prop `overrideStrings` so that UI strings can be presented in a different language
+
+default values for `overrideStrings` are as below
+
+```json
+{
+  "allItemsAreSelected": "All items are selected.",
+  "clearSearch": "Clear Search",
+  "clearSelected": "Clear Selected",
+  "noOptions": "No options",
+  "search": "Search",
+  "selectAll": "Select All",
+  "selectAllFiltered": "Select All (Filtered)",
+  "selectSomeItems": "Select...",
+  "create": "Create",
+}
+```

--- a/stories.bak/recipes/theming.stories.mdx
+++ b/stories.bak/recipes/theming.stories.mdx
@@ -1,0 +1,43 @@
+import { Meta } from "@storybook/addon-docs";
+
+<Meta title="recipes/Theming" />
+
+# 💅 Themeing
+
+You can override CSS variables to customize the appearance
+
+```css
+.rmsc {
+  --rmsc-main: #4285f4;
+  --rmsc-hover: #f1f3f5;
+  --rmsc-selected: #e2e6ea;
+  --rmsc-border: #ccc;
+  --rmsc-gray: #aaa;
+  --rmsc-bg: #fff;
+  --rmsc-p: 10px; /* Spacing */
+  --rmsc-radius: 4px; /* Radius */
+  --rmsc-h: 38px; /* Height */
+}
+```
+
+> 💡 use `!important` if CSS variables are not getting applied
+
+## Dark Mode
+
+if you are using any UI framework that supports dark mode and want to extend the same to `react-multi-select-component` you can do that by passing override class and styles like below
+
+```jsx
+<MultiSelect className="dark" {...otherProps} />
+```
+
+```css
+.rmsc.dark {
+  --rmsc-main: #4285f4;
+  --rmsc-hover: #0e0c0a;
+  --rmsc-selected: #1d1915;
+  --rmsc-border: #333333;
+  --rmsc-gray: #555555;
+  --rmsc-bg: #000000;
+  color: #fff;
+}
+```


### PR DESCRIPTION
Created second build for the CSP problem when using recommended strict policy on production.

`
import { MultiSelect } from "react-multi-select-component";
`

Would be changed (if needed) to:
`
import { MultiSelect } from "react-multi-select-component/no-inject-style";
import  "react-multi-select-component/no-inject-style/index.css";
`

Should help with those issues also.



https://github.com/hc-oss/react-multi-select-component/issues/655
https://github.com/hc-oss/react-multi-select-component/issues/516