### PR TITLE
feat(no-inject-style): Added second build witouth style injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ yarn add react-multi-select-component # yarn
 ```tsx
 import React, { useState } from "react";
 import { MultiSelect } from "react-multi-select-component";
+// or without style injection (in the presence of Content Security Policy issues)
+// import { MultiSelect } from "react-multi-select-component/no-inject-style";
+// import  "react-multi-select-component/no-inject-style/index.css";
 
 const options = [
   { label: "Grapes 🍇", value: "grapes" },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "build": "tsup src/index.tsx --inject-style --legacy-output --minify --format esm,cjs --dts --external react",
+    "build:no-inject-style": "tsup src/index.tsx --outDir dist/no-inject-style --legacy-output --minify --format esm,cjs --dts --external react",
+    "build:inject-style": "tsup src/index.tsx --inject-style --legacy-output --minify --format esm,cjs --dts --external react",
+    "build": "yarn run build:inject-style && yarn run build:no-inject-style",
     "dev": "tsup src/index.tsx --inject-style --legacy-output --format esm,cjs --watch --dts --external react",
     "lint": "eslint src --fix",
     "size": "size-limit",


### PR DESCRIPTION
Created a second build for the CSP problem when using recommended strict policy on production.

```tsx
import { MultiSelect } from "react-multi-select-component";
```

Would be changed (if needed) to:

```tsx
import { MultiSelect } from "react-multi-select-component/no-inject-style";
import  "react-multi-select-component/no-inject-style/index.css";
```

Should help with those issues also.



https://github.com/hc-oss/react-multi-select-component/issues/655
https://github.com/hc-oss/react-multi-select-component/issues/516